### PR TITLE
Miscellaneous tweaks and improvements

### DIFF
--- a/ftplugin/kerboscript.vim
+++ b/ftplugin/kerboscript.vim
@@ -1,0 +1,4 @@
+" smartindent autoindents after braces, which is pretty much all kerboscript
+" needs.
+setlocal smartindent
+

--- a/syntax/kerboscript.vim
+++ b/syntax/kerboscript.vim
@@ -47,7 +47,7 @@ syn keyword	ksFunction	add remove stage clearscreen log copy rename delete edit 
 hi def link	ksFunction	Function
 
 " Keywords "{{{1
-syn keyword	ksKeyword	set to lock unlock declare parameter toggle return
+syn keyword	ksKeyword	set to is lock unlock declare parameter toggle return
 hi def link	ksKeyword	Keyword
 
 " Numbers "{{{1
@@ -81,7 +81,7 @@ syn region	ksArraryIndex	start='\[' end='\]' fold transparent
 
 
 " Repeats "{{{1
-syn keyword	ksRepeat	for until
+syn keyword	ksRepeat	for until in
 hi def link	ksRepeat	Repeat
 
 " Statements "{{{1

--- a/syntax/kerboscript.vim
+++ b/syntax/kerboscript.vim
@@ -23,6 +23,8 @@ if exists("b:current_syntax")
 	finish
 endif
 
+syn case ignore
+
 " Booleans "{{{1
 syn keyword	ksBoolean	true false
 hi def link	ksBoolean	Boolean

--- a/syntax/kerboscript.vim
+++ b/syntax/kerboscript.vim
@@ -37,9 +37,13 @@ hi def link	ksConditional	Conditional
 syn keyword	ksConstant	pi e g
 hi def link	ksConstant	Constant
 
-" Floats "{{{1
-syn match	ksFloat		"\.\d\+\>"
-syn match	ksFloat		"\<\d\+\.\d*\>"
+" Numeric literals "{{{1
+" Regex design borrowed from python.vim. Order matters.
+syn match	ksNumber	"\v<\d+>"
+syn match	ksFloat		"\v<\d+e[-+]?\d+>"
+syn match	ksFloat		"\v<\d+\.%(e[-+]?\d+)?%(\W|$)@="
+syn match	ksFloat		"\v%(^|\W)@<=\d*\.\d+%(e[-+]?\d+)?>"
+hi def link	ksNumber	Number
 hi def link	ksFloat		Float
 
 " Functions "{{{1
@@ -49,10 +53,6 @@ hi def link	ksFunction	Function
 " Keywords "{{{1
 syn keyword	ksKeyword	set to is lock unlock declare parameter toggle return
 hi def link	ksKeyword	Keyword
-
-" Numbers "{{{1
-syn match	ksNumber	"\<\d\+\>"
-hi def link	ksNumber	Number
 
 " Operators "{{{1
 syn keyword	ksOperator	abs ceiling floor ln log10 mod min max round sqrt sin cos tan arcsin arccos arctan arctan2

--- a/syntax/kerboscript.vim
+++ b/syntax/kerboscript.vim
@@ -101,7 +101,7 @@ syn keyword	ksTodo		contained TODO
 hi def link	ksTodo		Todo
 
 " Types "{{{1
-syn keyword	ksType		function v vector direction latlng parameter
+syn keyword	ksType		function v r latlng parameter
 hi def link	ksType		Type
 " }}}
 


### PR DESCRIPTION
Included changes:

1. Case insensitivity.

2. Highlight "is" and "in".

3. More thorough highlighting of floating-point literals.

4. Rotation constructor "r" is a type highlight, for parity with "v".  "vector" and "direction" type highlights removed, as they don't seem to occupy the same place as v(), r(), and latlang().  Python.vim highlights a whole bunch of builtins as Function.  That might be the way to go with v(), r(), latlang(), list(), and any others I'm forgetting. 

5. Enable smartindent mode.  It seems to do the right thing.